### PR TITLE
feat: port functionality from __coverage__, get ready for first release

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,8 @@
 {
   "presets": ["es2015"],
+  "env": {
+    "test": {
+      "plugins": ["./lib"]
+    }
+  }
 }
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+
+os:
+  - linux
+
+after_success: npm run coverage
+
+node_js:
+  - "0.10"
+  - "4"
+  - "node"

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ You can also use [istanbul's ignore hints](https://github.com/gotwarlost/istanbu
 
 ## Credit where credit is due
 
-The approach used in `babel-plugin-istanbul` was inspired by [Thai Pangsakulyanont](https://github.com/dtinth)'s original library [babel-plugin-__coverage__](https://github.com/dtinth/babel-plugin-__coverage__).
+The approach used in `babel-plugin-istanbul` was inspired by [Thai Pangsakulyanont](https://github.com/dtinth)'s original library [`babel-plugin-__coverage__`](https://github.com/dtinth/babel-plugin-__coverage__).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
 # babel-plugin-istanbul
-A babel plugin that adds istanbul instrumentation to ES6 code
+
+A Babel plugin that instruments your code with Istanbul coverage.
+It can instantly be used with [karma-coverage](https://github.com/karma-runner/karma-coverage) and mocha on Node.js (through [nyc](https://github.com/bcoe/nyc)).
+
+__Note:__ This plugin does not generate any report or save any data to any file;
+it only adds instrumenting code to your JavaScript source code.
+To integrate with testing tools, please see the [Integrations](#integrations) section.
+
+## Usage
+
+Install it:
+
+```
+npm install --save-dev babel-plugin-istanbul
+```
+
+Add it to `.babelrc` in test mode:
+
+```js
+{
+  "env": {
+    "test": {
+      "plugins": [ "istanbul" ]
+    }
+  }
+}
+```
+
+Optionally, use [cross-env](https://www.npmjs.com/package/cross-env) to set
+`NODE_ENV=test`:
+
+```json
+{
+  "scripts": {
+    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha test/*.js"
+  }
+}
+```
+
+## Integrations
+
+### karma
+
+It _just works_ with Karma. First, make sure that the code is already transpiled by Babel (either using `karma-babel-preprocessor`, `karma-webpack`, or `karma-browserify`). Then, simply set up [karma-coverage](https://github.com/karma-runner/karma-coverage) according to the docs, but __don’t add the `coverage` preprocessor.__ This plugin has already instrumented your code, and Karma should pick it up automatically.
+
+It has been tested with [bemusic/bemuse](https://codecov.io/github/bemusic/bemuse) project, which contains ~2400 statements.
+
+### mocha on node.js (through nyc)
+
+Configure Mocha to transpile JavaScript code using Babel, then you can run your tests with [`nyc`](https://github.com/bcoe/nyc), which will collect all the coverage report.
+
+babel-plugin-istanbul respects the `include`/`exclude` configuration options from nyc,
+but you also need to __configure NYC not to instrument your code__ by adding these settings in your `package.json`:
+
+```js
+  "nyc": {
+    "sourceMap": false,
+    "instrument": false
+  },
+```
+
+## Ignoring files
+
+You don't want to cover your test files as this will skew your coverage results. You can configure this by configuring the plugin using nyc's [exclude/include syntax](https://github.com/bcoe/nyc#excluding-files).
+
+You can also use [istanbul's ignore hints](https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md#ignoring-code-for-coverage-purposes) to specify specific lines of code to skip instrumenting.
+
+## Credit where credit is due
+
+The approach used in `babel-plugin-istanbul` was inspired by [Thai Pangsakulyanont](https://github.com/dtinth)'s original library [babel-plugin-__coverage__](https://github.com/dtinth/babel-plugin-__coverage__).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # babel-plugin-istanbul
 
+[![Build Status](https://travis-ci.org/istanbuljs/babel-plugin-istanbul.svg)](https://travis-ci.org/istanbuljs/babel-plugin-istanbul)
+[![Coverage Status](https://coveralls.io/repos/github/istanbuljs/babel-plugin-istanbul/badge.svg?branch=master)](https://coveralls.io/github/istanbuljs/babel-plugin-istanbul?branch=master)
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
+
 A Babel plugin that instruments your code with Istanbul coverage.
 It can instantly be used with [karma-coverage](https://github.com/karma-runner/karma-coverage) and mocha on Node.js (through [nyc](https://github.com/bcoe/nyc)).
 

--- a/fixtures/should-cover.js
+++ b/fixtures/should-cover.js
@@ -1,0 +1,4 @@
+let foo = function () {
+  console.log('foo')
+}
+foo()

--- a/fixtures/should-not-cover.js
+++ b/fixtures/should-not-cover.js
@@ -1,0 +1,4 @@
+let bar = function () {
+  console.log('bar')
+}
+bar()

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "babel src --out-dir lib",
-    "pretest": "standard",
+    "pretest": "standard && npm run release",
     "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha test/*.js",
     "prepublish": "npm test && npm run release",
     "version": "standard-version"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       "fixtures/should-cover.js"
     ],
     "require": [
-      "babel-register"
+      "babel-core/register"
     ],
     "sourceMap": false,
     "instrument": false

--- a/package.json
+++ b/package.json
@@ -1,21 +1,34 @@
 {
   "name": "babel-plugin-istanbul",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0",
   "author": "Thai Pangsakulyanont @dtinth",
   "license": "BSD-3-Clause",
-  "description": "A babel plugin that adds istanbul instrumentation to ES6 code — Edit",
+  "description": "A babel plugin that adds istanbul instrumentation to ES6 code",
   "main": "lib/index.js",
   "dependencies": {
+    "find-up": "^1.1.2",
+    "istanbul-lib-instrument": "^1.1.0-alpha.1",
+    "test-exclude": "^1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.21",
-    "babel-preset-es2015": "^6.3.13"
+    "babel-preset-es2015": "^6.3.13",
+    "chai": "^3.5.0",
+    "coveralls": "^2.11.9",
+    "cross-env": "^1.0.8",
+    "mocha": "^2.5.3",
+    "nyc": "^6.6.1",
+    "standard": "^7.1.2",
+    "standard-version": "^2.3.1"
   },
   "scripts": {
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "babel src --out-dir lib",
-    "test": "echo no tests yet",
-    "prepublish": "npm test && npm run release"
+    "pretest": "standard",
+    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha test/*.js",
+    "prepublish": "npm test && npm run release",
+    "version": "standard-version"
   },
   "repository": {
     "type": "git",
@@ -27,6 +40,17 @@
     "plugin",
     "instrumentation"
   ],
+  "nyc": {
+    "include": [
+      "src/*.js",
+      "fixtures/should-cover.js"
+    ],
+    "require": [
+      "babel-register"
+    ],
+    "sourceMap": false,
+    "instrument": false
+  },
   "bugs": {
     "url": "https://github.com/istanbuljs/babel-plugin-istanbul/issues"
   },

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -1,0 +1,26 @@
+/* global describe, it */
+
+const babel = require('babel-core')
+import makeVisitor from '../src'
+
+require('chai').should()
+
+describe('babel-plugin-istanbul', function () {
+  it('should instrument file if shouldSkip returns false', function () {
+    var result = babel.transformFileSync('./fixtures/should-cover.js', {
+      plugins: [
+        makeVisitor({types: babel.types})
+      ]
+    })
+    result.code.should.match(/statementMap/)
+  })
+
+  it('should not instrument file if shouldSkip returns true', function () {
+    var result = babel.transformFileSync('./fixtures/should-not-cover.js', {
+      plugins: [
+        makeVisitor({types: babel.types})
+      ]
+    })
+    result.code.should.not.match(/statementMap/)
+  })
+})


### PR DESCRIPTION
I've tested this, and I believe it's ready for prime time:

* I've added tests (we'll probably want to build this suite out a bit further).
* I've wired up coverage (working from @gotwarlost's gist).
* I've added the ability to include/exclude files using nyc's syntax.
* I've pulled together a README using @dtinth's as a basis.

Next thing I'm going to do, is move `nyc` into the `istanbuljs` organization, @gotwarlost you're comfortable with `nyc` becoming `istanbuljs`' command-line interface going forward?

If so, I'm going to update the documentation accordingly, and release version `7.x.x` of nyc -- the main difference being that it will no longer load a `.istanbul.yml` (at least for the time being) -- instead, my goal will be to expose any configuration options necessary for istanbuljs in `nyc` itself.

reviewers: @dtinth, @gotwarlost 

fixes #1 