### PR TITLE
Pass realpath(process.cwd()) to test-exclude

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ let exclude
 function shouldSkip (file) {
   if (!exclude) {
     exclude = testExclude({
+      cwd: getRealpath(process.cwd()),
       configKey: 'nyc',
       configPath: dirname(findUp.sync('package.json'))
     })


### PR DESCRIPTION
This is a fix for #7.