### PR TITLE
fix: keep using NYC_CWD if available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ let exclude
 function shouldSkip (file) {
   if (!exclude) {
     exclude = testExclude({
-      cwd: getRealpath(process.cwd()),
+      cwd: process.env.NYC_CWD || getRealpath(process.cwd()),
       configKey: 'nyc',
       configPath: dirname(findUp.sync('package.json'))
     })


### PR DESCRIPTION
some libraries like ava change the `process.chdir()`, for file include/exclude rules we should stick with the value of `NYC_CWD` if it's available.

see: https://github.com/istanbuljs/nyc/issues/305