### PR TITLE
Allow exclude/include options to be passed as Babel plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,25 @@ but you also need to __configure NYC not to instrument your code__ by adding the
 
 ## Ignoring files
 
-You don't want to cover your test files as this will skew your coverage results. You can configure this by configuring the plugin using nyc's [exclude/include syntax](https://github.com/bcoe/nyc#excluding-files).
+You don't want to cover your test files as this will skew your coverage results. You can configure this by providing plugin options matching nyc's [`exclude`/`include` rules](https://github.com/bcoe/nyc#excluding-files):
+
+```js
+{
+  "env": {
+    "test": {
+      "plugins": [
+        ["istanbul", {
+          exclude: [
+            "**/*.spec.js"
+          ]
+        }]
+      ]
+    }
+  }
+}
+```
+
+If you don't provide options in your Babel config, the plugin will look for `exclude`/`include` config under an `"nyc"` key in `package.json`.
 
 You can also use [istanbul's ignore hints](https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md#ignoring-code-for-coverage-purposes) to specify specific lines of code to skip instrumenting.
 

--- a/fixtures/plugin-should-cover.js
+++ b/fixtures/plugin-should-cover.js
@@ -1,0 +1,4 @@
+let foo = function () {
+  console.log('foo')
+}
+foo()

--- a/fixtures/plugin-should-not-cover.js
+++ b/fixtures/plugin-should-not-cover.js
@@ -1,0 +1,4 @@
+let bar = function () {
+  console.log('bar')
+}
+bar()

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,9 @@ function getRealpath (n) {
 }
 
 let exclude
-function shouldSkip (file) {
+function shouldSkip (file, opts) {
   if (!exclude) {
-    exclude = testExclude({
+    exclude = testExclude(Object.keys(opts).length > 0 ? opts : {
       cwd: process.env.NYC_CWD || getRealpath(process.cwd()),
       configKey: 'nyc',
       configPath: dirname(findUp.sync('package.json'))
@@ -32,7 +32,7 @@ function makeVisitor ({types: t}) {
         enter (path) {
           this.__dv__ = null
           const realPath = getRealpath(this.file.opts.filename)
-          if (shouldSkip(realPath)) {
+          if (shouldSkip(realPath, this.opts)) {
             return
           }
           this.__dv__ = programVisitor(t, realPath)

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -1,4 +1,4 @@
-/* global describe, it */
+/* global context, describe, it */
 
 const babel = require('babel-core')
 import makeVisitor from '../src'
@@ -6,21 +6,47 @@ import makeVisitor from '../src'
 require('chai').should()
 
 describe('babel-plugin-istanbul', function () {
-  it('should instrument file if shouldSkip returns false', function () {
-    var result = babel.transformFileSync('./fixtures/should-cover.js', {
-      plugins: [
-        makeVisitor({types: babel.types})
-      ]
+  context('Babel plugin config', function () {
+    it('should instrument file if shouldSkip returns false', function () {
+      var result = babel.transformFileSync('./fixtures/plugin-should-cover.js', {
+        plugins: [
+          [makeVisitor({types: babel.types}), {
+            include: ['fixtures/plugin-should-cover.js']
+          }]
+        ]
+      })
+      result.code.should.match(/statementMap/)
     })
-    result.code.should.match(/statementMap/)
+
+    it('should not instrument file if shouldSkip returns true', function () {
+      var result = babel.transformFileSync('./fixtures/plugin-should-not-cover.js', {
+        plugins: [
+          [makeVisitor({types: babel.types}), {
+            include: ['fixtures/plugin-should-cover.js']
+          }]
+        ]
+      })
+      result.code.should.not.match(/statementMap/)
+    })
   })
 
-  it('should not instrument file if shouldSkip returns true', function () {
-    var result = babel.transformFileSync('./fixtures/should-not-cover.js', {
-      plugins: [
-        makeVisitor({types: babel.types})
-      ]
+  context('package.json "nyc" config', function () {
+    it('should instrument file if shouldSkip returns false', function () {
+      var result = babel.transformFileSync('./fixtures/should-cover.js', {
+        plugins: [
+          makeVisitor({types: babel.types})
+        ]
+      })
+      result.code.should.match(/statementMap/)
     })
-    result.code.should.not.match(/statementMap/)
+
+    it('should not instrument file if shouldSkip returns true', function () {
+      var result = babel.transformFileSync('./fixtures/should-not-cover.js', {
+        plugins: [
+          makeVisitor({types: babel.types})
+        ]
+      })
+      result.code.should.not.match(/statementMap/)
+    })
   })
 })


### PR DESCRIPTION
PR for #9 

From my testing, plugin options are set to `{}` when not provided, so I'm using being non-empty as the heuristic for using them instead of providing package.json lookup configuration.

Just merging `opts` into the existing config in `shouldSkip` would be a bit more straightforward, but I wasn't sure which versions of Node.js this plugin targets to know if I could use `Object.assign` or would need to pull in or write an alternative implementation.