### PR TITLE
Add files config to package.json to whitelist lib/

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "license": "BSD-3-Clause",
   "description": "A babel plugin that adds istanbul instrumentation to ES6 code",
   "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "find-up": "^1.1.2",
     "istanbul-lib-instrument": "^1.1.0-alpha.2",


### PR DESCRIPTION
There's currently a bunch of stuff in the npm package which doesn't need to be there:

https://npmcdn.com/babel-plugin-istanbul@1.0.3/

Adding a `files` whitelist is a simple way to prevent it from being included at packing time.