### PR TITLE
Drop support for Node <= 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ os:
 after_success: npm run coverage
 
 node_js:
-  - "0.10"
   - "4"
   - "node"

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/babel-plugin-istanbul/issues"
   },
-  "homepage": "https://github.com/istanbuljs/babel-plugin-istanbul#readme"
+  "homepage": "https://github.com/istanbuljs/babel-plugin-istanbul#readme",
+  "engines": {
+    "node": ">=4"
+  }
 }


### PR DESCRIPTION
I don't have a strong opinion about this, but this is technically required for the code I wrote in #37 (specifically [this use of `Object.assign`](https://github.com/istanbuljs/babel-plugin-istanbul/pull/37/commits/c225334ca1f954746c94b13dc7a09fa3edb93f5c) so `cwd` gets merged into `opts` rather than ignored). Sure there are possible workarounds to keep supporting Node 0.10, but it may be time to upgrade anyway.