### PR TITLE
fix: switch deprecated lodash.assign for object-assign

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ os:
 after_success: npm run coverage
 
 node_js:
-  - "0.10"
   - "4"
   - "node"
+
+# mock-fs breaks the test-suite in Node 0.10,
+# we circument this by skipping mock-fs related
+# tests. This hack is also required which prevents
+# mocha from loading mock-fs in files it instruments.
+matrix:
+    include:
+     - node_js: "0.10"
+       env: FS_MOCK=./package.json

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "find-up": "^1.1.2",
     "istanbul-lib-instrument": "^1.1.1",
-    "lodash.assign": "^4.2.0",
+    "object-assign": "^4.1.0",
     "test-exclude": "^2.1.1"
   },
   "devDependencies": {
@@ -20,7 +20,7 @@
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
-    "cross-env": "^2.0.0",
+    "cross-env": "^3.0.0",
     "mocha": "^3.0.2",
     "mock-fs": "^3.11.0",
     "nyc": "^8.1.0",
@@ -32,7 +32,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "babel src --out-dir lib",
     "pretest": "standard && npm run release",
-    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha test/*.js",
+    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha --require=${FS_MOCK:-mock-fs} test/*.js",
     "prepublish": "npm test && npm run release",
     "version": "standard-version"
   },
@@ -60,5 +60,10 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/babel-plugin-istanbul/issues"
   },
-  "homepage": "https://github.com/istanbuljs/babel-plugin-istanbul#readme"
+  "homepage": "https://github.com/istanbuljs/babel-plugin-istanbul#readme",
+  "greenkeeper": {
+    "ignore": [
+      "find-up"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
-    "cross-env": "^3.0.0",
+    "cross-env": "^2.0.1",
     "mocha": "^3.0.2",
     "mock-fs": "^3.11.0",
     "nyc": "^8.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import {realpathSync} from 'fs'
 import {dirname} from 'path'
 import {programVisitor} from 'istanbul-lib-instrument'
-import assign from 'lodash.assign'
+import assign from 'object-assign'
 
 const testExclude = require('test-exclude')
 const findUp = require('find-up')

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---require mock-fs


### PR DESCRIPTION
switch lodash.assign (which has been deprecated) to object-assign.

to get Node 0.10 tests running, I added a temporary (very _ugly_) hack to address mock-fs issues (CC: @motiz88