### PR TITLE
Make npm test script work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "babel src --out-dir lib",
     "pretest": "standard && npm run release",
-    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha --require=${FS_MOCK:-mock-fs} test/*.js",
+    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha --require=./test/utils/mock-fs test/*.js",
     "prepublish": "npm test && npm run release",
     "version": "standard-version"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "babel src --out-dir lib",
     "pretest": "standard && npm run release",
-    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha --require=./test/utils/mock-fs test/*.js",
+    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha --require=./test/utils/mock-fs.js test/*.js",
     "prepublish": "npm test && npm run release",
     "version": "standard-version"
   },

--- a/test/utils/mock-fs.js
+++ b/test/utils/mock-fs.js
@@ -1,0 +1,1 @@
+module.exports = require(process.env.FS_MOCK || 'mock-fs')


### PR DESCRIPTION
Windows doesn't have the same env var substitution syntax as Bash.
