### PR TITLE
Accept source map input for the visitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,40 @@ If you don't provide options in your Babel config, the plugin will look for `exc
 
 You can also use [istanbul's ignore hints](https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md#ignoring-code-for-coverage-purposes) to specify specific lines of code to skip instrumenting.
 
+## Source Maps
+
+By default, this plugin will pick up inline source maps and attach them to the instrumented code such that code coverage can be remapped back to the original source, even for multi-step build processes. This can be memory intensive. Set `useInlineSourceMaps` to prevent this behavior.
+
+```json
+{
+  "env": {
+    "test": {
+      "plugins": [
+        ["istanbul", {
+          "useInlineSourceMaps": false
+        }]
+      ]
+    }
+  }
+}
+```
+
+If you're instrumenting code programatically, you can pass a source map explicitly.
+```js
+import babelPluginIstanbul from 'babel-plugin-istanbul';
+
+function instrument(sourceCode, sourceMap, fileName) {
+  return babel.transform(sourceCode, {
+    filename,
+    plugins: [
+      [babelPluginIstanbul, {
+        inputSourceMap: sourceMap
+      }]
+    ]
+  })
+}
+```
+
 ## Credit where credit is due
 
 The approach used in `babel-plugin-istanbul` was inspired by [Thai Pangsakulyanont](https://github.com/dtinth)'s original library [`babel-plugin-__coverage__`](https://github.com/dtinth/babel-plugin-__coverage__).

--- a/fixtures/has-inline-source-map.js
+++ b/fixtures/has-inline-source-map.js
@@ -1,0 +1,12 @@
+"use strict";
+var Say = (function () {
+    function Say() {
+    }
+    Say.prototype.hello = function () {
+        console.log('hello');
+    };
+    return Say;
+}());
+exports.__esModule = true;
+exports["default"] = Say;
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiQ2hlY2tib3gudGVzdC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIkNoZWNrYm94LnRlc3QudHN4Il0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7QUFBQTtJQUFBO0lBSUEsQ0FBQztJQUhDLG1CQUFLLEdBQUw7UUFDRSxPQUFPLENBQUMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBQ3ZCLENBQUM7SUFDSCxVQUFDO0FBQUQsQ0FBQyxBQUpELElBSUMiLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCBjbGFzcyBTYXkge1xyXG4gIGhlbGxvKCkge1xyXG4gICAgY29uc29sZS5sb2coJ2hlbGxvJyk7XHJcbiAgfVxyXG59Il19"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
     "prepublish": "npm test && npm run release",
     "version": "standard-version"
   },
+  "standard": {
+    "ignore": [
+      "fixtures/has-inline-source-map.js"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/istanbuljs/babel-plugin-istanbul.git"

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,10 @@ function makeVisitor ({types: t}) {
           if (shouldSkip(realPath, this.opts)) {
             return
           }
-          this.__dv__ = programVisitor(t, realPath)
+          this.__dv__ = programVisitor(t, realPath, {
+            coverageVariable: '__coverage__',
+            inputSourceMap: this.opts.inputSourceMap || this.file.opts.inputSourceMap
+          })
           this.__dv__.enter(path)
         },
         exit (path) {

--- a/src/index.js
+++ b/src/index.js
@@ -43,9 +43,13 @@ function makeVisitor ({types: t}) {
           if (shouldSkip(realPath, this.opts)) {
             return
           }
+          let { inputSourceMap } = this.opts
+          if (this.opts.useInlineSourceMaps !== false) {
+            inputSourceMap = inputSourceMap || this.file.opts.inputSourceMap
+          }
           this.__dv__ = programVisitor(t, realPath, {
             coverageVariable: '__coverage__',
-            inputSourceMap: this.opts.inputSourceMap || this.file.opts.inputSourceMap
+            inputSourceMap
           })
           this.__dv__.enter(path)
         },

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -32,6 +32,43 @@ describe('babel-plugin-istanbul', function () {
     })
   })
 
+  context('source maps', function () {
+    it('should use inline source map', function () {
+      var result = babel.transformFileSync('./fixtures/has-inline-source-map.js', {
+        plugins: [
+          [makeVisitor({types: babel.types}), {
+            include: ['fixtures/has-inline-source-map.js']
+          }]
+        ]
+      })
+      result.code.should.match(/inputSourceMap/)
+    })
+
+    it('should not use inline source map if inputSourceMap is set to false', function () {
+      var result = babel.transformFileSync('./fixtures/has-inline-source-map.js', {
+        plugins: [
+          [makeVisitor({types: babel.types}), {
+            include: ['fixtures/has-inline-source-map.js'],
+            useInlineSourceMaps: false
+          }]
+        ]
+      })
+      result.code.should.not.match(/inputSourceMap/)
+    })
+
+    it('should use provided source map', function () {
+      var result = babel.transformFileSync('./fixtures/has-inline-source-map.js', {
+        plugins: [
+          [makeVisitor({types: babel.types}), {
+            include: ['fixtures/has-inline-source-map.js'],
+            inputSourceMap: { asdfQwer: 'foo' }
+          }]
+        ]
+      })
+      result.code.should.match(/inputSourceMap:\s*{\s*asdfQwer: "foo"\s*}/)
+    })
+  })
+
   context('package.json "nyc" config', function () {
     it('should instrument file if shouldSkip returns false', function () {
       var result = babel.transformFileSync('./fixtures/should-cover.js', {


### PR DESCRIPTION
If a source map is explicitly passed, prefer that, otherwise try and pluck an inline source map that babel may have already parsed from the file content.

Counterpart to - https://github.com/istanbuljs/istanbul-lib-instrument/pull/23/files#diff-c07343828715f64179d26d4c237cb63c
Ref - https://github.com/istanbuljs/istanbul-lib-source-maps/pull/4

Context - upstream PR for https://github.com/facebook/jest/pull/2290. Jest provides instrumentation using babel-plugin-istanbul, and currently there's disparity with source map support between `createInstrumenter().instrumentSync()` and this babel plugin. This PR resolves that so both approaches can thread a source map through and have it attached to coverage.