### PR TITLE
Add babel plugin to transform arrow functions

### DIFF
--- a/fixtures/should-transform-arrow-function.js
+++ b/fixtures/should-transform-arrow-function.js
@@ -1,0 +1,3 @@
+const foo = () => {}
+
+foo()

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lib"
   ],
   "dependencies": {
+    "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
     "find-up": "^1.1.2",
     "istanbul-lib-instrument": "^1.1.4",
     "object-assign": "^4.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import {realpathSync} from 'fs'
 import {dirname} from 'path'
 import {programVisitor} from 'istanbul-lib-instrument'
 import assign from 'object-assign'
+import transformArrowFunctions from 'babel-plugin-transform-es2015-arrow-functions'
 
 const testExclude = require('test-exclude')
 const findUp = require('find-up')
@@ -32,10 +33,12 @@ function makeShouldSkip () {
   }
 }
 
-function makeVisitor ({types: t}) {
+function makeVisitor (props) {
   const shouldSkip = makeShouldSkip()
+  const { visitor: { ArrowFunctionExpression } } = transformArrowFunctions(props)
   return {
     visitor: {
+      ArrowFunctionExpression,
       Program: {
         enter (path) {
           this.__dv__ = null
@@ -43,7 +46,7 @@ function makeVisitor ({types: t}) {
           if (shouldSkip(realPath, this.opts)) {
             return
           }
-          this.__dv__ = programVisitor(t, realPath)
+          this.__dv__ = programVisitor(props.types, realPath)
           this.__dv__.enter(path)
         },
         exit (path) {

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -8,6 +8,18 @@ import makeVisitor from '../src'
 require('chai').should()
 
 describe('babel-plugin-istanbul', function () {
+  it('transforms arrow functions', function () {
+    var result = babel.transformFileSync('./fixtures/should-transform-arrow-function.js', {
+      babelrc: false,
+      plugins: [
+        [makeVisitor({types: babel.types}), {
+          include: ['fixtures/should-transform-arrow-function.js']
+        }]
+      ]
+    })
+    result.code.should.not.contain('() => {')
+  })
+
   context('Babel plugin config', function () {
     it('should instrument file if shouldSkip returns false', function () {
       var result = babel.transformFileSync('./fixtures/plugin-should-cover.js', {


### PR DESCRIPTION
This is another piece to fixing #63. This handles the `Bar` arrow function that is defined.