### PR TITLE
fix: address regression related to export const foo = () => {}

### DIFF
--- a/fixtures/issue-78.js
+++ b/fixtures/issue-78.js
@@ -1,0 +1,12 @@
+export const updateName = (name) => {
+  return {
+    type: 'UPDATE_NAME',
+    name
+  }
+}
+export const updateName2 = (name) => {
+  return {
+    type: 'UPDATE_NAME',
+    name
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "find-up": "^1.1.2",
-    "istanbul-lib-instrument": "^1.4.1",
+    "istanbul-lib-instrument": "^1.4.2",
     "object-assign": "^4.1.0",
     "test-exclude": "^3.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "find-up": "^1.1.2",
-    "istanbul-lib-instrument": "^1.4.0",
+    "istanbul-lib-instrument": "^1.4.1",
     "object-assign": "^4.1.0",
     "test-exclude": "^3.3.0"
   },

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -165,4 +165,20 @@ describe('babel-plugin-istanbul', function () {
       })
     })
   }
+
+  // TODO: setup istanbul-lib-instrument, such that we can
+  // run various babel configurations.
+  context('regression tests', () => {
+    // regression test for https://github.com/istanbuljs/babel-plugin-istanbul/issues/78
+    it('should instrument: export const foo = () => {}', function () {
+      var result = babel.transformFileSync('./fixtures/issue-78.js', {
+        plugins: [
+          [makeVisitor({types: babel.types}), {
+            include: ['fixtures/issue-78.js']
+          }]
+        ]
+      })
+      result.code.match(/statementMap/)
+    })
+  })
 })


### PR DESCRIPTION
should address regression discussed in #78 