### PR TITLE
feat: add includeUntested option to expose coverage of all instrumented files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ function makeVisitor ({types: t}) {
           if (!this.__dv__) {
             return
           }
-          let result = this.__dv__.exit(path)
+          const result = this.__dv__.exit(path)
           if (this.opts.onCover) {
             this.opts.onCover(getRealpath(this.file.opts.filename), result.fileCoverage)
           }

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,11 @@ function makeVisitor ({types: t}) {
           if (!this.__dv__) {
             return
           }
-          this.__dv__.exit(path)
+          let result = this.__dv__.exit(path)
+          if (this.opts.includeUntested) {
+            global.__coverage__ = global.__coverage__ || {}
+            global.__coverage__[getRealpath(this.file.opts.filename)] = result.fileCoverage
+          }
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -58,9 +58,8 @@ function makeVisitor ({types: t}) {
             return
           }
           let result = this.__dv__.exit(path)
-          if (this.opts.includeUntested) {
-            global.__coverage__ = global.__coverage__ || {}
-            global.__coverage__[getRealpath(this.file.opts.filename)] = result.fileCoverage
+          if (this.opts.onCover) {
+            this.opts.onCover(getRealpath(this.file.opts.filename), result.fileCoverage)
           }
         }
       }

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -4,8 +4,9 @@ const babel = require('babel-core')
 import mockProcess from 'pmock'
 import fs from 'fs'
 import makeVisitor from '../src'
+import path from 'path'
 
-require('chai').should()
+var should = require('chai').should()
 
 describe('babel-plugin-istanbul', function () {
   context('Babel plugin config', function () {
@@ -29,6 +30,36 @@ describe('babel-plugin-istanbul', function () {
         ]
       })
       result.code.should.not.match(/statementMap/)
+    })
+
+    it('should expose fileCoverage in global scope when includeUntested is set to true', function () {
+      var __coverage__ = global.__coverage__
+      delete global.__coverage__
+      babel.transformFileSync('./fixtures/plugin-should-cover.js', {
+        plugins: [
+          [makeVisitor({types: babel.types}), {
+            includeUntested: true,
+            include: ['fixtures/plugin-should-cover.js']
+          }]
+        ]
+      })
+      should.exist(global.__coverage__)
+      should.exist(global.__coverage__[path.resolve('./fixtures/plugin-should-cover.js')])
+      global.__coverage__ = __coverage__
+    })
+
+    it('should not expose fileCoverage in global scope when includeUntested is not set', function () {
+      var __coverage__ = global.__coverage__
+      delete global.__coverage__
+      babel.transformFileSync('./fixtures/plugin-should-cover.js', {
+        plugins: [
+          [makeVisitor({types: babel.types}), {
+            include: ['fixtures/plugin-should-cover.js']
+          }]
+        ]
+      })
+      should.not.exist(global.__coverage__)
+      global.__coverage__ = __coverage__
     })
   })
 

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -6,7 +6,7 @@ import fs from 'fs'
 import makeVisitor from '../src'
 import path from 'path'
 
-var should = require('chai').should()
+require('chai').should()
 
 describe('babel-plugin-istanbul', function () {
   context('Babel plugin config', function () {
@@ -32,34 +32,20 @@ describe('babel-plugin-istanbul', function () {
       result.code.should.not.match(/statementMap/)
     })
 
-    it('should expose fileCoverage in global scope when includeUntested is set to true', function () {
-      var __coverage__ = global.__coverage__
-      delete global.__coverage__
+    it('should call onCover callback', function () {
+      var args
       babel.transformFileSync('./fixtures/plugin-should-cover.js', {
         plugins: [
           [makeVisitor({types: babel.types}), {
-            includeUntested: true,
+            onCover: function () {
+              args = [].slice.call(arguments)
+            },
             include: ['fixtures/plugin-should-cover.js']
           }]
         ]
       })
-      should.exist(global.__coverage__)
-      should.exist(global.__coverage__[path.resolve('./fixtures/plugin-should-cover.js')])
-      global.__coverage__ = __coverage__
-    })
-
-    it('should not expose fileCoverage in global scope when includeUntested is not set', function () {
-      var __coverage__ = global.__coverage__
-      delete global.__coverage__
-      babel.transformFileSync('./fixtures/plugin-should-cover.js', {
-        plugins: [
-          [makeVisitor({types: babel.types}), {
-            include: ['fixtures/plugin-should-cover.js']
-          }]
-        ]
-      })
-      should.not.exist(global.__coverage__)
-      global.__coverage__ = __coverage__
+      args[0].should.equal(path.resolve('./fixtures/plugin-should-cover.js'))
+      args[1].statementMap.should.exist
     })
   })
 


### PR DESCRIPTION
This allows reporting on all instrumented files even if they are not `require`d.