### PR TITLE
nyc command line include parameter  fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,11 @@ function makeShouldSkip () {
   return function shouldSkip (file, opts) {
     if (!exclude) {
       const cwd = getRealpath(process.env.NYC_CWD || process.cwd())
-      const include = process.env.NYC_CONFIG ? JSON.parse(process.env.NYC_CONFIG).include : false
+      const defaults = process.env.NYC_CONFIG ? JSON.parse(process.env.NYC_CONFIG) : {}
       exclude = testExclude(assign(
         { cwd },
         Object.keys(opts).length > 0 ? opts : {
-          include: include,
+          include: defaults.include,
           configKey: 'nyc',
           configPath: dirname(findUp.sync('package.json', { cwd }))
         }

--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,11 @@ function makeShouldSkip () {
   return function shouldSkip (file, opts) {
     if (!exclude) {
       const cwd = getRealpath(process.env.NYC_CWD || process.cwd())
-      const config = JSON.parse(process.env.NYC_CONFIG)
+      const include = process.env.NYC_CONFIG ? JSON.parse(process.env.NYC_CONFIG).include : undefined
       exclude = testExclude(assign(
         { cwd },
         Object.keys(opts).length > 0 ? opts : {
-          include: config.include,
+          include: include,
           configKey: 'nyc',
           configPath: dirname(findUp.sync('package.json', { cwd }))
         }

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,11 @@ function makeShouldSkip () {
   return function shouldSkip (file, opts) {
     if (!exclude) {
       const cwd = getRealpath(process.env.NYC_CWD || process.cwd())
+      const config = JSON.parse(process.env.NYC_CONFIG)
       exclude = testExclude(assign(
         { cwd },
         Object.keys(opts).length > 0 ? opts : {
+          include: config.include,
           configKey: 'nyc',
           configPath: dirname(findUp.sync('package.json', { cwd }))
         }

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ function makeShouldSkip () {
   return function shouldSkip (file, opts) {
     if (!exclude) {
       const cwd = getRealpath(process.env.NYC_CWD || process.cwd())
-      const include = process.env.NYC_CONFIG ? JSON.parse(process.env.NYC_CONFIG).include : undefined
+      const include = process.env.NYC_CONFIG ? JSON.parse(process.env.NYC_CONFIG).include : false
       exclude = testExclude(assign(
         { cwd },
         Object.keys(opts).length > 0 ? opts : {


### PR DESCRIPTION
nyc command line include parameter was being ignored and package.json nyc/include values were being used everytime.
Fix #82