### PR TITLE
feat: drop Node 0.10 and 0.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ after_success: npm run coverage
 
 node_js:
   - "4"
-  - "node"
+  - "6"
+  - "stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,3 @@ after_success: npm run coverage
 node_js:
   - "4"
   - "node"
-
-# mock-fs breaks the test-suite in Node 0.10,
-# we circument this by skipping mock-fs related
-# tests. This hack is also required which prevents
-# mocha from loading mock-fs in files it instruments.
-matrix:
-    include:
-     - node_js: "0.10"
-       env: FS_MOCK=./package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # babel-plugin-istanbul
 
-[![Build Status](https://travis-ci.org/istanbuljs/babel-plugin-istanbul.svg)](https://travis-ci.org/istanbuljs/babel-plugin-istanbul)
+[![Build Status](https://travis-ci.org/istanbuljs/babel-plugin-istanbul.svg?branch=master)](https://travis-ci.org/istanbuljs/babel-plugin-istanbul)
 [![Coverage Status](https://coveralls.io/repos/github/istanbuljs/babel-plugin-istanbul/badge.svg?branch=master)](https://coveralls.io/github/istanbuljs/babel-plugin-istanbul?branch=master)
 [![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
 

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "lib"
   ],
   "dependencies": {
-    "find-up": "^1.1.2",
+    "find-up": "^2.1.0",
     "istanbul-lib-instrument": "^1.4.2",
     "object-assign": "^4.1.0",
-    "test-exclude": "^3.3.0"
+    "test-exclude": "^4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
@@ -20,9 +20,8 @@
     "babel-preset-es2015": "^6.18.0",
     "chai": "^3.5.0",
     "coveralls": "^2.11.15",
-    "cross-env": "^2.0.1",
+    "cross-env": "^3.1.4",
     "mocha": "^3.2.0",
-    "mock-fs": "^3.12.1",
     "nyc": "^10.0.0",
     "pmock": "^0.2.3",
     "standard": "^8.6.0",
@@ -32,7 +31,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "babel src --out-dir lib",
     "pretest": "standard && npm run release",
-    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha --require=${FS_MOCK:-mock-fs} test/*.js",
+    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha test/*.js",
     "prepublish": "npm test && npm run release",
     "version": "standard-version"
   },

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -1,8 +1,6 @@
 /* eslint-env mocha */
 
 const babel = require('babel-core')
-import mockProcess from 'pmock'
-import fs from 'fs'
 import makeVisitor from '../src'
 
 require('chai').should()
@@ -88,83 +86,6 @@ describe('babel-plugin-istanbul', function () {
       result.code.should.not.match(/statementMap/)
     })
   })
-
-  // Regression tests for https://github.com/istanbuljs/babel-plugin-istanbul/issues/7
-  if (!/^v0\.10/.test(process.version)) { // mock-fs does not work on Node 0.10.
-    const mockFs = require('mock-fs')
-    context('when current path uses a symlink', function () {
-      beforeEach(function () {
-        mockFs({
-          '/project': {
-            'fixtures': {
-              'should-cover.js': fs.readFileSync('./fixtures/should-cover.js')
-            },
-            'package.json': fs.readFileSync('./package.json')
-          },
-          '/symlink': mockFs.symlink({path: '/project'})
-        })
-      })
-
-      const shouldInstrument = file => {
-        var result = babel.transformFileSync(file, {
-          plugins: [
-            makeVisitor({types: babel.types})
-          ]
-        })
-        result.code.should.match(/statementMap/)
-      }
-
-      context('and NYC_CWD is set', function () {
-        var env
-
-        beforeEach(function () {
-          env = mockProcess.env({
-            NYC_CWD: '/symlink'
-          })
-        })
-
-        it('should instrument file accessed via link', function () {
-          shouldInstrument('/symlink/fixtures/should-cover.js')
-        })
-
-        it('should instrument file accessed via real path', function () {
-          shouldInstrument('/project/fixtures/should-cover.js')
-        })
-
-        afterEach(function () {
-          env.reset()
-        })
-      })
-
-      context('and only process.cwd() is set', function () {
-        var env, cwd
-
-        beforeEach(function () {
-          env = mockProcess.env({
-            NYC_CWD: ''
-          })
-          cwd = mockProcess.cwd(fs.realpathSync('/symlink')) // realpath because of mock-fs Windows quirk re: process.cwd
-        })
-
-        it('should instrument file accessed via link', function () {
-          shouldInstrument('/symlink/fixtures/should-cover.js')
-        })
-
-        it('should instrument file accessed via real path', function () {
-          shouldInstrument('/project/fixtures/should-cover.js')
-        })
-
-        afterEach(function () {
-          env.reset()
-          cwd.reset()
-        })
-      })
-
-      afterEach(function () {
-        mockFs.restore()
-      })
-    })
-  }
 
   // TODO: setup istanbul-lib-instrument, such that we can
   // run various babel configurations.


### PR DESCRIPTION
BREAKING CHANGE: I've updated dependencies and dropped Node 0.10 and Node 0.12 support.

* we've also pulled in the new version of test-exclude that excludes `/coverage`.
* and dropped `mock-fs` (I liked these tests, but mock-fs seems to run _really_ slow on some versions of Node.js unfortunately).