### PR TITLE
fix: load configuration from process.env.NYC_CONFIG if present

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-core": "^6.21.0",
     "babel-preset-es2015": "^6.18.0",
     "chai": "^3.5.0",
-    "coveralls": "^2.11.15",
+    "coveralls": "^2.11.16",
     "cross-env": "^3.1.4",
     "mocha": "^3.2.0",
     "nyc": "^10.0.0",

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -68,22 +68,52 @@ describe('babel-plugin-istanbul', function () {
   })
 
   context('package.json "nyc" config', function () {
-    it('should instrument file if shouldSkip returns false', function () {
-      var result = babel.transformFileSync('./fixtures/should-cover.js', {
-        plugins: [
-          makeVisitor({types: babel.types})
-        ]
+    context('process.env.NYC_CONFIG is set', function () {
+      it('should instrument file if shouldSkip returns false', function () {
+        var result = babel.transformFileSync('./fixtures/should-cover.js', {
+          plugins: [
+            makeVisitor({types: babel.types})
+          ]
+        })
+        result.code.should.match(/statementMap/)
       })
-      result.code.should.match(/statementMap/)
+
+      it('should not instrument file if shouldSkip returns true', function () {
+        var result = babel.transformFileSync('./fixtures/should-not-cover.js', {
+          plugins: [
+            makeVisitor({types: babel.types})
+          ]
+        })
+        result.code.should.not.match(/statementMap/)
+      })
     })
 
-    it('should not instrument file if shouldSkip returns true', function () {
-      var result = babel.transformFileSync('./fixtures/should-not-cover.js', {
-        plugins: [
-          makeVisitor({types: babel.types})
-        ]
+    context('process.env.NYC_CONFIG is not set', function () {
+      const OLD_NYC_CONFIG = process.env.NYC_CONFIG
+      before(() => {
+        delete process.env.NYC_CONFIG
       })
-      result.code.should.not.match(/statementMap/)
+      after(() => {
+        process.env.NYC_CONFIG = OLD_NYC_CONFIG
+      })
+
+      it('should instrument file if shouldSkip returns false', function () {
+        var result = babel.transformFileSync('./fixtures/should-cover.js', {
+          plugins: [
+            makeVisitor({types: babel.types})
+          ]
+        })
+        result.code.should.match(/statementMap/)
+      })
+
+      it('should not instrument file if shouldSkip returns true', function () {
+        var result = babel.transformFileSync('./fixtures/should-not-cover.js', {
+          plugins: [
+            makeVisitor({types: babel.types})
+          ]
+        })
+        result.code.should.not.match(/statementMap/)
+      })
     })
   })
 


### PR DESCRIPTION
If present, we should load configuration from `process.env.NYC_CONFIG` this adds tests to the work undertaken by @alpersogukpinar in #84.

fixes #82