### PR TITLE
chore: explicitly upgrade instrumenter

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "find-up": "^2.1.0",
-    "istanbul-lib-instrument": "^1.7.2",
+    "istanbul-lib-instrument": "^1.7.5",
     "test-exclude": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
explicitly upgrade to instrumenter with @tomchentw's support for named exports.