### PR TITLE
fix: include object-spread-syntax plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "lib"
   ],
   "dependencies": {
+    "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "find-up": "^2.1.0",
-    "istanbul-lib-instrument": "^1.7.5",
+    "istanbul-lib-instrument": "^1.8.0",
     "test-exclude": "^4.1.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import {realpathSync} from 'fs'
 import {dirname} from 'path'
 import {programVisitor} from 'istanbul-lib-instrument'
+import babelSyntaxObjectRestSpread from 'babel-plugin-syntax-object-rest-spread'
 
 const testExclude = require('test-exclude')
 const findUp = require('find-up')
@@ -23,7 +24,7 @@ function makeShouldSkip () {
       let config = {}
       if (Object.keys(opts).length > 0) {
         // explicitly configuring options in babel
-        // takes precendence.
+        // takes precedence.
         config = opts
       } else if (nycConfig.include || nycConfig.exclude) {
         // nyc was configured in a parent process (keep these settings).
@@ -52,6 +53,7 @@ function makeShouldSkip () {
 function makeVisitor ({types: t}) {
   const shouldSkip = makeShouldSkip()
   return {
+    inherits: babelSyntaxObjectRestSpread,
     visitor: {
       Program: {
         enter (path) {


### PR DESCRIPTION
Adding this plugin allows Babel to parse the syntax. It does _not_ transpile it, so the user still needs to transpile it if running on a node version which does not support it. But this means that consumers don't have to add this plugin just so Babel can parse their code.

Will fix https://github.com/facebook/jest/issues/5082