### PR TITLE
chore: explicit update of istanbul dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "find-up": "^2.1.0",
-    "istanbul-lib-instrument": "^1.8.0",
-    "test-exclude": "^4.1.1"
+    "istanbul-lib-instrument": "^1.10.1",
+    "test-exclude": "^4.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
address bad release of istanbul-lib-instrument.