### PR TITLE
fix: respect changes of cwd in options

### DIFF
--- a/fixtures/should-respect-cwd.js
+++ b/fixtures/should-respect-cwd.js
@@ -1,0 +1,4 @@
+let foo = function () {
+  console.log('foo')
+}
+foo()

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ function getRealpath (n) {
 function makeShouldSkip () {
   let exclude
   return function shouldSkip (file, opts) {
-    if (!exclude) {
+    if (!exclude || exclude.cwd !== opts.cwd) {
       const cwd = getRealpath(process.env.NYC_CWD || process.cwd())
       const nycConfig = process.env.NYC_CONFIG ? JSON.parse(process.env.NYC_CONFIG) : {}
 
@@ -44,7 +44,6 @@ function makeShouldSkip () {
         config
       ))
     }
-
     return !exclude.shouldInstrument(file)
   }
 }

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -148,5 +148,25 @@ describe('babel-plugin-istanbul', function () {
       })
       result.code.match(/statementMap/)
     })
+
+    it('should respect a changed cwd in options', function () {
+      var resultBefore = babel.transformFileSync('./fixtures/should-respect-cwd.js', {
+        plugins: [
+          [makeVisitor({types: babel.types}), {
+            cwd: '/Users/juretriglav/src/babel-plugin-istanbul/fixtures'
+          }]
+        ]
+      })
+      resultBefore.code.should.match(/statementMap/)
+
+      var resultAfter = babel.transformFileSync('./fixtures/should-respect-cwd.js', {
+        plugins: [
+          [makeVisitor({types: babel.types}), {
+            cwd: '/Users/juretriglav/src/babel-plugin-istanbul/lib'
+          }]
+        ]
+      })
+      resultAfter.code.should.not.match(/statementMap/)
+    })
   })
 })

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -153,16 +153,15 @@ describe('babel-plugin-istanbul', function () {
       var resultBefore = babel.transformFileSync('./fixtures/should-respect-cwd.js', {
         plugins: [
           [makeVisitor({types: babel.types}), {
-            cwd: '/Users/juretriglav/src/babel-plugin-istanbul/fixtures'
+            cwd: path.resolve(__dirname, '..', 'fixtures')
           }]
         ]
       })
       resultBefore.code.should.match(/statementMap/)
-
       var resultAfter = babel.transformFileSync('./fixtures/should-respect-cwd.js', {
         plugins: [
           [makeVisitor({types: babel.types}), {
-            cwd: '/Users/juretriglav/src/babel-plugin-istanbul/lib'
+            cwd: path.resolve(__dirname, '..', 'lib')
           }]
         ]
       })

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -150,22 +150,25 @@ describe('babel-plugin-istanbul', function () {
     })
 
     it('should respect a changed cwd in options', function () {
+      const opts = {
+        cwd: path.resolve(__dirname, '..', 'lib')
+      }
+      const plugins = [
+        [makeVisitor, opts]
+      ]
+
       var resultBefore = babel.transformFileSync('./fixtures/should-respect-cwd.js', {
-        plugins: [
-          [makeVisitor({types: babel.types}), {
-            cwd: path.resolve(__dirname, '..', 'fixtures')
-          }]
-        ]
+        plugins
       })
-      resultBefore.code.should.match(/statementMap/)
+
+      resultBefore.code.should.not.match(/statementMap/)
+
+      opts.cwd = path.resolve(__dirname, '..', 'fixtures')
+
       var resultAfter = babel.transformFileSync('./fixtures/should-respect-cwd.js', {
-        plugins: [
-          [makeVisitor({types: babel.types}), {
-            cwd: path.resolve(__dirname, '..', 'lib')
-          }]
-        ]
+        plugins
       })
-      resultAfter.code.should.not.match(/statementMap/)
+      resultAfter.code.should.match(/statementMap/)
     })
   })
 })


### PR DESCRIPTION
Well, this one took a while.

Long story short, sometimes during runtime, the `cwd` in `opts` for `shouldSkip` does change (e.g. a multi-project Jest setup) through `babel-jest` https://github.com/facebook/jest/blob/master/packages/babel-jest/src/index.js#L125-L134, and if `exclude` https://github.com/istanbuljs/babel-plugin-istanbul/blob/master/src/index.js#L19 isn't 'redone' at that point, it will falsely exclude files from instrumentation (as it's using the previous/initial cwd).

I believe this is the cause for numerous missing coverage issues in multi-project setups. I'm only aware of Jest issues https://github.com/facebook/jest/issues/5417 https://github.com/facebook/jest/issues/5457 https://github.com/facebook/jest/issues/6483, which is what we're using, but there might be others.

In any case, it probably makes sense to rebuild `exclude` if `cwd`, its crucial option, changes, so that's what I've done. Also added a test for it.

Let me know if this feels ok!