### PR TITLE
Support turning off node_modules default exclude via flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ build/Release
 
 # Dependency directories
 node_modules
+!fixtures/node_modules
 jspm_packages
 
 # Optional npm cache directory

--- a/fixtures/node_modules/should-cover.js
+++ b/fixtures/node_modules/should-cover.js
@@ -1,0 +1,4 @@
+let foo = function () {
+  console.log('foo')
+}
+foo()

--- a/fixtures/node_modules/should-not-cover.js
+++ b/fixtures/node_modules/should-not-cover.js
@@ -1,0 +1,4 @@
+let bar = function () {
+  console.log('bar')
+}
+bar()

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,9 @@ function makeShouldSkip () {
         // nyc was configured in a parent process (keep these settings).
         config = {
           include: nycConfig.include,
-          exclude: nycConfig.exclude
+          exclude: nycConfig.exclude,
+          // Make sure this is true unless explicitly set to `false`. `undefined` is still `true`.
+          excludeNodeModules: nycConfig.excludeNodeModules !== false
         }
       } else {
         // fallback to loading config from key in package.json.

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -30,6 +30,32 @@ describe('babel-plugin-istanbul', function () {
       result.code.should.not.match(/statementMap/)
     })
 
+    context('local node_modules', function () {
+      it('should instrument file if shouldSkip returns false', function () {
+        var result = babel.transformFileSync('./fixtures/node_modules/should-cover.js', {
+          plugins: [
+            [makeVisitor({ types: babel.types }), {
+              excludeNodeModules: false,
+              exclude: ['node_modules/**'],
+              include: ['fixtures/node_modules/should-cover.js']
+            }]
+          ]
+        })
+        result.code.should.match(/statementMap/)
+      })
+
+      it('should not instrument file if shouldSkip returns true', function () {
+        var result = babel.transformFileSync('./fixtures/node_modules/should-not-cover.js', {
+          plugins: [
+            [makeVisitor({ types: babel.types }), {
+              include: ['fixtures/node_modules/should-not-cover.js']
+            }]
+          ]
+        })
+        result.code.should.not.match(/statementMap/)
+      })
+    })
+
     it('should call onCover callback', function () {
       var args
       babel.transformFileSync('./fixtures/plugin-should-cover.js', {


### PR DESCRIPTION
This PR is part of resolving [issue #898](https://github.com/istanbuljs/nyc/issues/898). The idea is to be able to turn off the default exclusion of `**/node_modules/**` for users that need/want to support local `node_modules`. As mentioned in that issue, the `negateExclude` (i.e. `!**/node_modules/**`) doesn't work for cases when you still want your exclusion list to still exclude matches within your local `node_modules` directory. 

Related PRs for solving the above issue:
- https://github.com/istanbuljs/istanbuljs/pull/213
- https://github.com/istanbuljs/nyc/pull/912

**NOTE:** this test-exclude PR (https://github.com/istanbuljs/istanbuljs/pull/213) will need to get merged and published before this is effective.