### PR TITLE
fix: Ensure correct scope references after traversal

### DIFF
--- a/fixtures/with-changed-scope.js
+++ b/fixtures/with-changed-scope.js
@@ -1,0 +1,2 @@
+import { noop } from 'lodash'
+noop(noop() ? noop : noop)

--- a/package-lock.json
+++ b/package-lock.json
@@ -987,6 +987,19 @@
         }
       }
     },
+    "babel-plugin-lodash": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0-beta.49",
+        "@babel/types": "^7.0.0-beta.49",
+        "glob": "^7.1.1",
+        "lodash": "^4.17.10",
+        "require-package-name": "^2.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -6816,6 +6829,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
     "@babel/register": "^7.0.0",
+    "babel-plugin-lodash": "^3.3.4",
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
     "cross-env": "^5.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,9 @@ function makeVisitor ({ types: t }) {
             inputSourceMap
           })
           this.__dv__.enter(path)
+          // Istanbul visitor may replace Identifiers and require re-crawling
+          // scope before continuing with other babel plugins.
+          path.scope.crawl()
         },
         exit (path) {
           if (!this.__dv__) {

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -171,4 +171,55 @@ describe('babel-plugin-istanbul', function () {
       resultAfter.code.should.match(/statementMap/)
     })
   })
+
+  describe('should leave scope with correct references', function () {
+    it('leaves scope references as Identifiers', function () {
+      // This is a unit test which inspects the root cause of the problem:
+      // scope references that are replaced to no longer be Identifiers
+      babel.transformFileSync('./fixtures/with-changed-scope.js', {
+        babelrc: false,
+        configFile: false,
+        plugins: [
+          [makeVisitor({ types: babel.types }), {
+            include: ['fixtures/with-changed-scope.js']
+          }],
+          function testScope (t) {
+            return {
+              visitor: {
+                ImportSpecifier (path) {
+                  const fileScope = path.hub.file.scope
+                  const localBinding = fileScope.getBinding(path.node.local.name)
+                  for (const localReference of localBinding.referencePaths) {
+                    localReference.type.should.equal('Identifier')
+                  }
+                }
+              }
+            }
+          }
+        ]
+      })
+    })
+
+    it('creates valid syntax with other transforming plugins', function () {
+      // This is a minimal end-to-end test which illustrates how scope
+      // reference alteration impacts the assumptions of other plugins
+      const result = babel.transformFileSync(
+        './fixtures/with-changed-scope.js', {
+          babelrc: false,
+          configFile: false,
+          plugins: [
+            [makeVisitor({ types: babel.types }), {
+              include: ['fixtures/with-changed-scope.js']
+            }],
+            'babel-plugin-lodash'
+          ]
+        })
+
+      function testSyntaxError () {
+        babel.parse(result.code)
+      }
+
+      testSyntaxError.should.not.throw()
+    })
+  })
 })


### PR DESCRIPTION
(Replaces https://github.com/istanbuljs/istanbuljs/pull/283)

This fixes a bug that can be seen when istanbul coverage is enabled for a babel@7 project which uses reference replacement, such as `babel-plugin-lodash` or` babel-plugin-ramda`.

The root issue is that plugins like these assume that scope references will always be Identifiers but Istanbul may replace an identifier with a SequenceExpression. In babel@7 this replacement overwrites the existing scope reference and later plugin scope reference replacement is at best unsafe and at worst may result in an invalid AST.

This seems like a pretty unfortunate situation, and ideally Babel automatically maintains these scope references during transforms or the many packages using scope would account for this situation. The pattern I see in other first-class babel plugins prefer to re-crawl scope after a transform which can affect identifiers (example: https://github.com/babel/minify/blob/master/packages/babel-plugin-minify-dead-code-elimination/src/index.js#L969)

To follow that example, I'm proposing this fix that crawls the scope after the path traversal - ensuring any subsequent references to scope get correct references.

I tested this in a project that used istanbul via jest along with babel-plugin-lodash that suffered from this issue and found that with this patch the issue was resolved and the inspected compiled output looked correct.

I'm also including two tests in this repo to illustrate the issue directly. One test illustrates it directly with the Babel plugin API and another with a popular babel plugin which uses this API and suffers from the issue. Both tests fail in master and pass with the fix applied.