### PR TITLE
fix: Terminate NYC config loader in Electron

### DIFF
--- a/src/load-nyc-config-sync.js
+++ b/src/load-nyc-config-sync.js
@@ -2,13 +2,12 @@
 'use strict'
 
 const { loadNycConfig } = require('@istanbuljs/load-nyc-config')
-const isElectron = process.versions && process.versions.electron
 
 async function main () {
   const [cwd, nycrcPath] = process.argv.slice(2)
 
   console.log(JSON.stringify(await loadNycConfig({ cwd, nycrcPath })))
-  if (isElectron) process.exit(0)
+  process.exit(0)
 }
 
 main().catch(error => {

--- a/src/load-nyc-config-sync.js
+++ b/src/load-nyc-config-sync.js
@@ -2,13 +2,16 @@
 'use strict'
 
 const { loadNycConfig } = require('@istanbuljs/load-nyc-config')
+const isElectron = process.versions && process.versions.electron
 
 async function main () {
   const [cwd, nycrcPath] = process.argv.slice(2)
 
   console.log(JSON.stringify(await loadNycConfig({ cwd, nycrcPath })))
+  if (isElectron) process.exit(0)
 }
 
 main().catch(error => {
   console.log(JSON.stringify({ 'load-nyc-config-sync-error': error.message }))
+  if (isElectron) process.exit(1)
 })

--- a/src/load-nyc-config-sync.js
+++ b/src/load-nyc-config-sync.js
@@ -13,5 +13,5 @@ async function main () {
 
 main().catch(error => {
   console.log(JSON.stringify({ 'load-nyc-config-sync-error': error.message }))
-  if (isElectron) process.exit(1)
+  process.exit(0)
 })


### PR DESCRIPTION
In Electron the main process will not terminate automatically; this causes the plugin to hang during initialization. This commit calls `process.exit` explicitly after the config (or error message) has been sent back to the original process.

I added the `isElectron` check there to make sure everything stays the same in Node.js although it should be fine to just always exit by default.