### PR TITLE
chore(sourcemap): convert inputSourceMap to plain js object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,20 @@ function getRealpath (n) {
   }
 }
 
+function isPlainObject(value) {
+  if (
+    typeof value !== "object" ||
+    Object.prototype.toString.call(value) !== "[object Object]"
+  ) {
+    return false
+  }
+  const proto = Object.getPrototypeOf(value)
+  // Object.prototype's __proto__ is null. Every other class's __proto__.__proto__ is
+  // not null by default. We cannot check if proto === Object.prototype because it
+  // could come from another realm.
+  return proto === null || Object.getPrototypeOf(proto) === null
+}
+
 const memoize = new Map()
 /* istanbul ignore next */
 const memosep = path.sep === '/' ? ':' : ';'
@@ -113,6 +127,9 @@ export default declare(api => {
           if (this.opts.useInlineSourceMaps !== false) {
             if (!inputSourceMap && this.file.inputMap) {
               inputSourceMap = this.file.inputMap.sourcemap
+              if (!isPlainObject(sourceMapFromFile)) {
+                inputSourceMap = {...inputSourceMap};
+              }
             }
           }
           const visitorOptions = {}


### PR DESCRIPTION
@babel/core recently made a change where the sourcemap is no longer a plain js
object, but instead is a class SourceMap. This breaks when the coverage data
gets passed into valueToNode by istanbul-lib-instrument because the coverage
data is no longer entirely plain json objects (this.cov.toJSON() just returns
the data and doesn't do any conversion).

In this PR we are checking if the input sourcemap is a plain js object, and
converting it if it is not.