### PR TITLE
Update package dependencies and Babel configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,24 +9,24 @@
     "lib"
   ],
   "dependencies": {
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@istanbuljs/load-nyc-config": "^1.0.0",
-    "@istanbuljs/schema": "^0.1.2",
-    "istanbul-lib-instrument": "^5.0.4",
-    "test-exclude": "^6.0.0"
+    "@babel/helper-plugin-utils": "^7.24.7",
+    "@istanbuljs/load-nyc-config": "^1.1.0",
+    "@istanbuljs/schema": "^0.1.3",
+    "istanbul-lib-instrument": "^6.0.3",
+    "test-exclude": "^7.0.1"
   },
   "devDependencies": {
-    "@babel/cli": "^7.7.5",
-    "@babel/core": "^7.7.5",
-    "@babel/plugin-transform-modules-commonjs": "^7.7.5",
-    "@babel/register": "^7.7.4",
-    "chai": "^4.2.0",
-    "coveralls": "^3.0.9",
-    "cross-env": "^6.0.3",
-    "mocha": "^6.2.2",
-    "nyc": "^15.0.0",
+    "@babel/cli": "^7.24.7",
+    "@babel/core": "^7.24.7",
+    "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+    "@babel/register": "^7.24.6",
+    "chai": "^5.1.1",
+    "coveralls": "^3.1.1",
+    "cross-env": "^7.0.3",
+    "mocha": "^10.6.0",
+    "nyc": "^17.0.0",
     "pmock": "^0.2.3",
-    "standard": "^14.3.1"
+    "standard": "^17.1.0"
   },
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/test/babel-plugin-istanbul.js
+++ b/test/babel-plugin-istanbul.js
@@ -4,12 +4,13 @@ import * as babel from '@babel/core'
 import makeVisitor from '../src'
 import path from 'path'
 
-require('chai').should()
-
 describe('babel-plugin-istanbul', function () {
+  before(async () => {
+    await import('chai').then(c => { c.should() })
+  })
   context('Babel plugin config', function () {
     it('should instrument file if shouldSkip returns false', function () {
-      var result = babel.transformFileSync('./fixtures/plugin-should-cover.js', {
+      const result = babel.transformFileSync('./fixtures/plugin-should-cover.js', {
         babelrc: false,
         configFile: false,
         plugins: [
@@ -22,7 +23,7 @@ describe('babel-plugin-istanbul', function () {
     })
 
     it('should not instrument file if shouldSkip returns true', function () {
-      var result = babel.transformFileSync('./fixtures/plugin-should-not-cover.js', {
+      const result = babel.transformFileSync('./fixtures/plugin-should-not-cover.js', {
         babelrc: false,
         configFile: false,
         plugins: [
@@ -36,7 +37,7 @@ describe('babel-plugin-istanbul', function () {
 
     context('local node_modules', function () {
       it('should instrument file if shouldSkip returns false', function () {
-        var result = babel.transformFileSync('./fixtures/node_modules/should-cover.js', {
+        const result = babel.transformFileSync('./fixtures/node_modules/should-cover.js', {
           babelrc: false,
           configFile: false,
           plugins: [
@@ -51,7 +52,7 @@ describe('babel-plugin-istanbul', function () {
       })
 
       it('should not instrument file if shouldSkip returns true', function () {
-        var result = babel.transformFileSync('./fixtures/node_modules/should-not-cover.js', {
+        const result = babel.transformFileSync('./fixtures/node_modules/should-not-cover.js', {
           babelrc: false,
           configFile: false,
           plugins: [
@@ -65,7 +66,7 @@ describe('babel-plugin-istanbul', function () {
     })
 
     it('should call onCover callback', function () {
-      var args
+      let args
       babel.transformFileSync('./fixtures/plugin-should-cover.js', {
         babelrc: false,
         configFile: false,
@@ -85,7 +86,7 @@ describe('babel-plugin-istanbul', function () {
 
   context('source maps', function () {
     it('should use inline source map', function () {
-      var result = babel.transformFileSync('./fixtures/has-inline-source-map.js', {
+      const result = babel.transformFileSync('./fixtures/has-inline-source-map.js', {
         babelrc: false,
         configFile: false,
         plugins: [
@@ -98,7 +99,7 @@ describe('babel-plugin-istanbul', function () {
     })
 
     it('should not use inline source map if inputSourceMap is set to false', function () {
-      var result = babel.transformFileSync('./fixtures/has-inline-source-map.js', {
+      const result = babel.transformFileSync('./fixtures/has-inline-source-map.js', {
         babelrc: false,
         configFile: false,
         plugins: [
@@ -112,7 +113,7 @@ describe('babel-plugin-istanbul', function () {
     })
 
     it('should use provided source map', function () {
-      var result = babel.transformFileSync('./fixtures/has-inline-source-map.js', {
+      const result = babel.transformFileSync('./fixtures/has-inline-source-map.js', {
         babelrc: false,
         configFile: false,
         plugins: [
@@ -197,7 +198,7 @@ describe('babel-plugin-istanbul', function () {
   context('package.json "nyc" config', function () {
     context('process.env.NYC_CONFIG is set', function () {
       it('should instrument file if shouldSkip returns false', function () {
-        var result = babel.transformFileSync('./fixtures/should-cover.js', {
+        const result = babel.transformFileSync('./fixtures/should-cover.js', {
           babelrc: false,
           configFile: false,
           plugins: [
@@ -208,7 +209,7 @@ describe('babel-plugin-istanbul', function () {
       })
 
       it('should not instrument file if shouldSkip returns true', function () {
-        var result = babel.transformFileSync('./fixtures/should-not-cover.js', {
+        const result = babel.transformFileSync('./fixtures/should-not-cover.js', {
           babelrc: false,
           configFile: false,
           plugins: [
@@ -234,7 +235,7 @@ describe('babel-plugin-istanbul', function () {
       })
 
       it('should instrument file if shouldSkip returns false', function () {
-        var result = babel.transformFileSync('./fixtures/should-cover.js', {
+        const result = babel.transformFileSync('./fixtures/should-cover.js', {
           babelrc: false,
           configFile: false,
           plugins: [
@@ -245,7 +246,7 @@ describe('babel-plugin-istanbul', function () {
       })
 
       it('should not instrument file if shouldSkip returns true', function () {
-        var result = babel.transformFileSync('./fixtures/should-not-cover.js', {
+        const result = babel.transformFileSync('./fixtures/should-not-cover.js', {
           babelrc: false,
           configFile: false,
           plugins: [
@@ -300,7 +301,7 @@ describe('babel-plugin-istanbul', function () {
   context('regression tests', () => {
     // regression test for https://github.com/istanbuljs/babel-plugin-istanbul/issues/78
     it('should instrument: export const foo = () => {}', function () {
-      var result = babel.transformFileSync('./fixtures/issue-78.js', {
+      const result = babel.transformFileSync('./fixtures/issue-78.js', {
         babelrc: false,
         configFile: false,
         plugins: [
@@ -314,7 +315,7 @@ describe('babel-plugin-istanbul', function () {
 
     // regression test for https://github.com/istanbuljs/babel-plugin-istanbul/issues/201
     it('should not conflict with transform-modules-commonjs', function () {
-      var result = babel.transformFileSync('./fixtures/issue-201.js', {
+      const result = babel.transformFileSync('./fixtures/issue-201.js', {
         babelrc: false,
         configFile: false,
         plugins: [


### PR DESCRIPTION
```

> babel-plugin-istanbul@6.1.1 pretest
> standard && npm run release


> babel-plugin-istanbul@6.1.1 release
> babel src --out-dir lib

Successfully compiled 2 files with Babel (167ms).

> babel-plugin-istanbul@6.1.1 test
> cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha --timeout 5000 test/*.js



  babel-plugin-istanbul
    Babel plugin config
      ✔ should instrument file if shouldSkip returns false (56ms)
      ✔ should not instrument file if shouldSkip returns true
      ✔ should call onCover callback
      local node_modules
        ✔ should instrument file if shouldSkip returns false
        ✔ should not instrument file if shouldSkip returns true
    source maps
      ✔ should use inline source map
      ✔ should not use inline source map if inputSourceMap is set to false
      ✔ should use provided source map
    instrument options
      ✔ should honor coverageVariable option
      ✔ should honor coverageGlobalScope option
      ✔ should honor coverageGlobalScope option
      ✔ should honor ignoreClassMethods option
    package.json "nyc" config
      process.env.NYC_CONFIG is set
        ✔ should instrument file if shouldSkip returns false
        ✔ should not instrument file if shouldSkip returns true
      process.env.NYC_CONFIG is not set
        ✔ should instrument file if shouldSkip returns false (349ms)
        ✔ should not instrument file if shouldSkip returns true
        ✔ should load config using cwd (1094ms)
    regression tests
      ✔ should instrument: export const foo = () => {}
      ✔ should not conflict with transform-modules-commonjs (45ms)


  19 passing (2s)

-------------------------|---------|----------|---------|---------|-------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------------|---------|----------|---------|---------|-------------------
All files                |     100 |      100 |     100 |     100 |                   
 index.js                |     100 |      100 |     100 |     100 |                   
 load-nyc-config-sync.js |     100 |      100 |     100 |     100 |                   
-------------------------|---------|----------|---------|---------|-------------------

```