### PR TITLE
feat: add support for skipping coverage

### DIFF
--- a/fixtures/normal-coverage-test.js
+++ b/fixtures/normal-coverage-test.js
@@ -1,0 +1,17 @@
+// This file should be instrumented normally
+// because it has no skip markers
+
+function shouldBeCovered() {
+  console.log("This function should appear in coverage");
+  return "covered";
+}
+
+const normalFunction = (param) => {
+  if (param > 0) {
+    return param * 2;
+  }
+  return 0;
+};
+
+shouldBeCovered();
+normalFunction(5);

--- a/fixtures/skip-coverage-alt.js
+++ b/fixtures/skip-coverage-alt.js
@@ -1,0 +1,11 @@
+/* skip-coverage */
+
+// This file should also be skipped from coverage
+// because of the skip-coverage comment
+
+function alsoSkipped() {
+  console.log("This should not be instrumented");
+  return 42;
+}
+
+export default alsoSkipped;

--- a/fixtures/skip-coverage-test.js
+++ b/fixtures/skip-coverage-test.js
@@ -1,0 +1,15 @@
+/* istanbul ignore file */
+
+// This file should be completely skipped from coverage
+// because of the ignore comment at the top
+
+function shouldNotBeCovered() {
+  console.log("This function should not appear in coverage");
+  return "skipped";
+}
+
+const anotherFunction = () => {
+  return "also skipped";
+};
+
+export { shouldNotBeCovered, anotherFunction };

--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
   "nyc": {
     "include": [
       "src/*.js",
-      "fixtures/should-cover.js"
+      "fixtures/should-cover.js",
+      "fixtures/normal-coverage-test.js",
+      "fixtures/skip-coverage-test.js",
+      "fixtures/skip-coverage-alt.js"
     ],
     "require": [
       "@babel/register"


### PR DESCRIPTION
This pull request introduces enhancements to the Babel plugin for Istanbul to improve coverage handling, specifically for skipping files or sections based on comments or programmatic markers. It also includes updates to test cases, fixtures, and configuration files to support these changes.

### Why

In my real-world use case, I integrated this library into a React Native project. However, the app breaks because the instrumentation code is inserted into worklet closures, which is not allowed by the Reanimated library. I couldn’t find a way to avoid this with the current plugin interface, so I created this PR to enhance the skipping capabilities. I also plan to create a separate plugin that automatically adds skip markers to files containing worklet functions.

### Enhancements to coverage skipping logic:

* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L92-R123): Updated the `makeShouldSkip` function to support skipping files based on programmatic markers (`_skipCoverage`) or file-level comments (`istanbul ignore file` or `skip-coverage`). The function now returns detailed skip reasons. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L92-R123) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L109-R137)
* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L139-R172): Modified the Babel plugin to integrate the updated `shouldSkip` logic, ensuring files marked for skipping are excluded from coverage instrumentation.

### Updates to fixtures:

* [`fixtures/normal-coverage-test.js`](diffhunk://#diff-c30ae6d9b78a26414d38de6cf56d3851f20ad0e20a6670209261fec950b9b553R1-R17): Added a new file to test normal coverage instrumentation.
* [`fixtures/skip-coverage-test.js`](diffhunk://#diff-71b4176fb93536e6105bd7de490aa353a3445e0538ce73ecb9b90db37c81ed66R1-R15): Added a file with an `istanbul ignore file` comment to test skipping based on ignore comments.
* [`fixtures/skip-coverage-alt.js`](diffhunk://#diff-828ccb90d1b885106e0a18f25283a7dbeb71c7117e1208266d1ac798abb6743aR1-R11): Added a file with a `skip-coverage` comment to test alternative skip markers.

### Configuration and test updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L57-R60): Updated the `nyc` configuration to include the new test fixtures for coverage handling.
* [`test/babel-plugin-istanbul.js`](diffhunk://#diff-4599058a9be2054dee22b54c12c8cf4c4eedd1f21bff33c7f550de13eb29552eR346-R431): Added test cases to verify skipping behavior for files with ignore comments, `skip-coverage` comments, programmatic markers, and normal files without skip markers.

### Code style improvements:

* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L24-R24): Refactored code for better readability, including formatting changes in functions like `findConfig` and `loadNycConfig`. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L24-R24) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L56-R59) [[3]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L119-R155)