### PR TITLE
Add support for Babel 8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,16 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
+      # The test/babel-8 workspace depends on Babel 8, which requires Node 20+,
+      # so we cannot install dependencies with --engine-strict. We keep
+      # --engine-strict for older Node.js version, which use a npm version that
+      # does not support nested workspaces so doesn't see the Babel 8 dependencies,
+      # to make sure that we are not accidentally using dependencies that don't
+      # support Node.js 12+.
+      - run: npm install
+        if: matrix.node == 16 || matrix.node == 18
       - run: npm install --engine-strict
+        if: matrix.node != 16 && matrix.node != 18
       - run: npm test
   windows:
     runs-on: windows-latest

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "pmock": "^0.2.3",
     "standard": "^14.3.1"
   },
+  "workspaces": ["test/babel-8"],
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "babel src --out-dir lib",

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ function makeShouldSkip () {
 }
 
 export default declare(api => {
-  api.assertVersion(7)
+  api.assertVersion('^7.0.0 || ^8.0.0-beta.1')
 
   const shouldSkip = makeShouldSkip()
 

--- a/test/babel-8/package.json
+++ b/test/babel-8/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "devDependencies": {
+    "@babel/core": "^8.0.0-beta.2",
+    "@babel/plugin-transform-block-scoping": "^8.0.0-beta.2",
+    "@babel/plugin-transform-modules-commonjs": "^8.0.0-beta.2"
+  }
+}


### PR DESCRIPTION
Hi!

The Babel 8 release is almost ready, and we are only waiting until major packages in the Babel ecosystem are ready.

This PR makes `babel-plugin-istanbul` work with both Babel 7 and Babel 8, testing both versions in CI :)

It's one of the blockers that I found when try to update Jest to use Babel 8 by default (cc @SimenB, since I see you in both orgs :P)

Fixes #298
Closes #299