### PR TITLE
Use `prepublishOnly` instead of `prepublish` for npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "release": "babel src --out-dir lib",
     "pretest": "standard && npm run release",
     "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha --timeout 5000 test/*.js",
-    "prepublish": "npm test && npm run release"
+    "prepublishOnly": "npm test && npm run release"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
See https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts. `prepublish` runs after `npm install`, rather than on publish, which is probably not intended.

That's why tests are currently also running when using `npm install`.