### PR TITLE
chore: set registry-url to npmjs for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm install
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Hey @SimenB, I tried something to fix the release, in the [documentation](https://docs.github.com/en/actions/tutorials/publish-packages/publish-nodejs-packages#publishing-packages-to-the-npm-registry) of the node-setup action, they do state that you need to specify a registry url:

> Please note that you need to set the registry-url to https://registry.npmjs.org/ in setup-node to properly configure your credentials.

Without it, I believe that the .npmrc file is not created, and therefore npm publish might not be using the auth token. Which also seems to correspond to what I pointed out  in my [comment](https://github.com/istanbuljs/babel-plugin-istanbul/pull/301#issuecomment-3333148411).

I'm not 100% sure, the release might also be failing because we are now using a different registry URL, and therefore the NPM_TOKEN in the secrets might not be the correct one for this new registry.
