### PR TITLE
feat(ci/cd): switch to `npm` trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,9 @@ on:
      branches:
        - master
 name: release-please
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -21,6 +24,4 @@ jobs:
       - run: npm install
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Fixes #325 

This PR is to switch `npm` publish from token-based to trusted publishing, eliminates long-lived token for longevity. However, the project's maintainer needs to walk through this [section](https://docs.npmjs.com/trusted-publishers#configuring-trusted-publishing) to setup necessary config on `npm` side, as this PR is to implement 2nd part.

Once the PR is merged and packages version 8.x got released, it'll resolve a breed of issue on deprecated `glob` and `inflight` package.