### PR TITLE
Resolve "Workspaces can only be enabled in private projects" warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-istanbul",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "author": "Thai Pangsakulyanont @dtinth",
   "license": "BSD-3-Clause",
   "description": "A babel plugin that adds istanbul instrumentation to ES6 code",
@@ -29,9 +29,6 @@
     "pmock": "^0.2.3",
     "standard": "^14.3.1"
   },
-  "workspaces": [
-    "test/babel-8"
-  ],
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "babel src --out-dir lib",


### PR DESCRIPTION
Resolve the "Workspaces can only be enabled in private projects." warning, by removing the "workspaces" array.